### PR TITLE
Remove duplicate key 'extra-bindings' from metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,5 +24,3 @@ requires:
 peers:
   cluster:
     interface: ceph-iscsi-peer
-extra-bindings:
-  public:


### PR DESCRIPTION
Remove duplicate key 'extra-bindings' from metadata.yaml

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>